### PR TITLE
Remove a package from `setup.tex` that caused compilation issues.

### DIFF
--- a/setup.tex
+++ b/setup.tex
@@ -5,7 +5,6 @@
     % font encoding is set up for pdflatex, for other environments see
     % http://tex.stackexchange.com/questions/44694/fontenc-vs-inputenc
     \usepackage[T1]{fontenc}  % 8-bit fonts, improves handling of hyphenations
-    \usepackage[utf8x]{inputenc}
     % provides `old' commands for table of contents. Eases the ability to switch
     % between book and scrbook
     \usepackage{scrhack}


### PR DESCRIPTION
The template couldn't be compiled out of the box after importing into overleaf. This is fixed now.

See also [this commit](https://git.fachschaft.tf/fachschaft-public/thesis-template/-/commit/f818d941ec0572a4382f0680be8992db150f6d5c) for details.